### PR TITLE
(chores): optimize binary writes for numbers and time

### DIFF
--- a/hashstructure.go
+++ b/hashstructure.go
@@ -6,6 +6,7 @@ import (
 	"hash"
 	"hash/fnv"
 	"io"
+	"math"
 	"reflect"
 	"time"
 )
@@ -115,6 +116,7 @@ type walker struct {
 	ignorezerovalue bool
 	sets            bool
 	stringer        bool
+	buf             [16]byte // Reusable buffer for binary encoding
 }
 
 type visitOpts struct {
@@ -131,8 +133,54 @@ var timeType = reflect.TypeOf(time.Time{})
 // A direct hash calculation used for numeric and bool values.
 func (w *walker) hashDirect(v any) (uint64, error) {
 	w.h.Reset()
-	err := binary.Write(w.h, binary.LittleEndian, v)
-	return w.h.Sum64(), err
+
+	// Use direct byte manipulation for numbers instead of binary.Write to avoid allocations
+	switch val := v.(type) {
+	case int64:
+		binary.LittleEndian.PutUint64(w.buf[:8], uint64(val))
+		w.h.Write(w.buf[:8])
+	case uint64:
+		binary.LittleEndian.PutUint64(w.buf[:8], val)
+		w.h.Write(w.buf[:8])
+	case int8:
+		w.buf[0] = byte(val)
+		w.h.Write(w.buf[:1])
+	case uint8:
+		w.buf[0] = val
+		w.h.Write(w.buf[:1])
+	case int16:
+		binary.LittleEndian.PutUint16(w.buf[:2], uint16(val))
+		w.h.Write(w.buf[:2])
+	case uint16:
+		binary.LittleEndian.PutUint16(w.buf[:2], val)
+		w.h.Write(w.buf[:2])
+	case int32:
+		binary.LittleEndian.PutUint32(w.buf[:4], uint32(val))
+		w.h.Write(w.buf[:4])
+	case uint32:
+		binary.LittleEndian.PutUint32(w.buf[:4], val)
+		w.h.Write(w.buf[:4])
+	case float32:
+		binary.LittleEndian.PutUint32(w.buf[:4], math.Float32bits(val))
+		w.h.Write(w.buf[:4])
+	case float64:
+		binary.LittleEndian.PutUint64(w.buf[:8], math.Float64bits(val))
+		w.h.Write(w.buf[:8])
+	case complex64:
+		binary.LittleEndian.PutUint32(w.buf[:4], math.Float32bits(real(val)))
+		binary.LittleEndian.PutUint32(w.buf[4:8], math.Float32bits(imag(val)))
+		w.h.Write(w.buf[:8])
+	case complex128:
+		binary.LittleEndian.PutUint64(w.buf[:8], math.Float64bits(real(val)))
+		binary.LittleEndian.PutUint64(w.buf[8:16], math.Float64bits(imag(val)))
+		w.h.Write(w.buf[:16])
+	default:
+		// Fallback to binary.Write for unsupported types, for instance enums
+		err := binary.Write(w.h, binary.LittleEndian, v)
+		return w.h.Sum64(), err
+	}
+
+	return w.h.Sum64(), nil
 }
 
 // A direct hash calculation used for strings.
@@ -218,8 +266,8 @@ func (w *walker) visit(v reflect.Value, opts *visitOpts) (uint64, error) {
 			return 0, err
 		}
 
-		err = binary.Write(w.h, binary.LittleEndian, b)
-		return w.h.Sum64(), err
+		w.h.Write(b)
+		return w.h.Sum64(), nil
 	}
 
 	switch k {
@@ -435,16 +483,10 @@ func hashUpdateOrdered(h hash.Hash64, a, b uint64) uint64 {
 	// For ordered updates, use a real hash function
 	h.Reset()
 
-	// We just panic if the binary writes fail because we are writing
-	// an int64 which should never be fail-able.
-	e1 := binary.Write(h, binary.LittleEndian, a)
-	e2 := binary.Write(h, binary.LittleEndian, b)
-	if e1 != nil {
-		panic(e1)
-	}
-	if e2 != nil {
-		panic(e2)
-	}
+	var buf [16]byte
+	binary.LittleEndian.PutUint64(buf[0:8], a)
+	binary.LittleEndian.PutUint64(buf[8:16], b)
+	h.Write(buf[:])
 
 	return h.Sum64()
 }
@@ -470,11 +512,9 @@ func hashUpdateUnordered(a, b uint64) uint64 {
 func hashFinishUnordered(h hash.Hash64, a uint64) uint64 {
 	h.Reset()
 
-	// We just panic if the writes fail
-	e1 := binary.Write(h, binary.LittleEndian, a)
-	if e1 != nil {
-		panic(e1)
-	}
+	var buf [8]byte
+	binary.LittleEndian.PutUint64(buf[:], a)
+	h.Write(buf[:])
 
 	return h.Sum64()
 }


### PR DESCRIPTION
This PR optimizes binary write allocation for Number and time types.

It replaces binary.Write with a shared buffer and direct writes to the buffer for those types.

```
goos: darwin
goarch: arm64
pkg: github.com/johannes94/hashstructure
cpu: Apple M4 Pro
                  │   old.txt    │               new.txt               │
                  │    sec/op    │    sec/op     vs base               │
Map-14              3.348µ ± 15%   3.057µ ± 18%       ~ (p=0.190 n=10)
String/default-14   55.65n ± 10%   60.32n ± 17%       ~ (p=0.315 n=10)
String/xxhash-14    28.04n ± 27%   31.06n ± 22%       ~ (p=0.697 n=10)
geomean             173.5n         178.9n        +3.11%

                  │  old.txt   │               new.txt               │
                  │    B/op    │    B/op     vs base                 │
Map-14              953.0 ± 0%   985.0 ± 0%  +3.36% (p=0.000 n=10)
String/default-14   56.00 ± 0%   56.00 ± 0%       ~ (p=1.000 n=10) ¹
String/xxhash-14    16.00 ± 0%   16.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean             94.87        95.92       +1.11%
¹ all samples are equal

                  │   old.txt   │               new.txt                │
                  │  allocs/op  │ allocs/op   vs base                  │
Map-14              112.00 ± 0%   69.00 ± 0%  -38.39% (p=0.000 n=10)
String/default-14    3.000 ± 0%   3.000 ± 0%        ~ (p=1.000 n=10) ¹
String/xxhash-14     1.000 ± 0%   1.000 ± 0%        ~ (p=1.000 n=10) ¹
geomean              6.952        5.915       -14.91%
¹
```